### PR TITLE
feat: Provide Laravel 10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ dist: trusty
 group: edge
 
 php:
-  - 7.2.5
-  - 7.3
-  - 7.4
+  - 8.0
+  - 8.1
+  - 8.2
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-  
+
 language: php
 sudo: required
 dist: trusty
@@ -16,7 +16,7 @@ services:
 
 before_script:
   - mysql -u root -e 'create database laravelexceptionnotifier;'
-  - curl -s http://getcomposer.org/installer | php
+  - curl -s https://getcomposer.org/installer | php
   - php composer.phar install
   - composer create-project --prefer-dist laravel/laravel laravelexceptionnotifier
   - cp .env.travis laravelexceptionnotifier/.env

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^8.0"
     },
     "require-dev": {
-        "laravel/framework": "9.*"
+        "laravel/framework": "9.*|10.*"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ Register the package with laravel in `config/app.php` under `providers` with the
 #### Laravel 9 and Above use:
 
 ```php
-    use App\Mail\ExceptionOccured;
+    use App\Mail\ExceptionOccurred;
     use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
     use Illuminate\Support\Facades\Log;
     use Mail;
@@ -164,7 +164,7 @@ Register the package with laravel in `config/app.php` under `providers` with the
             $content['url'] = request()->url();
             $content['body'] = request()->all();
             $content['ip'] = request()->ip();
-            Mail::send(new ExceptionOccured($content));
+            Mail::send(new ExceptionOccurred($content));
         } catch (Throwable $exception) {
             Log::error($exception);
         }
@@ -224,7 +224,7 @@ Register the package with laravel in `config/app.php` under `providers` with the
         ├── .env.example
         ├── App
         │   ├── Mail
-        │   │   └── ExceptionOccured.php
+        │   │   └── ExceptionOccurred.php
         │   └── Traits
         │       └── ExceptionNotificationHandlerTrait.php
         ├── LaravelExceptionNotifier.php

--- a/readme.md
+++ b/readme.md
@@ -77,11 +77,7 @@ Register the package with laravel in `config/app.php` under `providers` with the
 #### Laravel 9 and Above use:
 
 ```php
-    use App\Mail\ExceptionOccurred;
-    use Illuminate\Support\Facades\Log;
-    use Illuminate\Support\Facades\Mail;
-    use Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer;
-    use Throwable;
+    use App\Traits\ExceptionNotificationHandlerTrait;
 ```
 
 #### Laravel 8 and Below use:
@@ -97,24 +93,15 @@ Register the package with laravel in `config/app.php` under `providers` with the
 5. Update `App\Exceptions\Handler.php`
 
 #### Laravel 9 and Above:
-##### In `App\Exceptions\Handler.php` replace the `register()` method with:
 
+##### Add trait to `Handler` class:
 ```php
-    /**
-     * Register the exception handling callbacks for the application.
-     *
-     * @return void
-     */
-    public function register()
-    {
-        $this->reportable(function (Throwable $e) {
-            $this->sendEmail($e);
-        });
-    }
+    use ExceptionNotificationHandlerTrait;
 ```
 
 #### Laravel 8 and Below:
-##### In `App\Exceptions\Handler.php` replace the `report()` method with:
+
+##### Replace the `report()` method with:
 
 ```php
     /**
@@ -142,37 +129,7 @@ Register the package with laravel in `config/app.php` under `providers` with the
     }
 ```
 
-6. In `App\Exceptions\Handler.php` add the method `sendEmail()`:
-
-#### Laravel 9 and Above:
-
-```php
-    /**
-     * Sends an email upon exception.
-     *
-     * @param Throwable $exception
-     *
-     * @return void
-     */
-    public function sendEmail(Throwable $exception)
-    {
-       try {
-            $content['message'] = $exception->getMessage();
-            $content['file'] = $exception->getFile();
-            $content['line'] = $exception->getLine();
-            $content['trace'] = $exception->getTrace();
-            $content['url'] = request()->url();
-            $content['body'] = request()->all();
-            $content['ip'] = request()->ip();
-            Mail::send(new ExceptionOccurred($content));
-        } catch (Throwable $exception) {
-            Log::error($exception);
-        }
-    }
-```
-
-#### Laravel 8 and Below:
-
+##### Add the method `sendEmail()`:
 ```php
     /**
      * Sends an email upon exception.
@@ -195,9 +152,9 @@ Register the package with laravel in `config/app.php` under `providers` with the
     }
 ```
 
-7. Configure your email settings in the `.env` file.
+6. Configure your email settings in the `.env` file.
 
-8. Add the following (optional) settings to your `.env` file and enter your settings:
+7. Add the following (optional) settings to your `.env` file and enter your settings:
 
     * **Note:** the defaults for these are located in `config/exception.php`
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Laravel Exception Notifier | A Laravel 5, 6, 7, 8, and 9 Exceptions Email Notification [Package](https://packagist.org/packages/jeremykenedy/laravel-exception-notifier)
+# Laravel Exception Notifier | A Laravel 5, 6, 7, 8, 9 and 10 Exceptions Email Notification [Package](https://packagist.org/packages/jeremykenedy/laravel-exception-notifier)
 
 [![Total Downloads](https://poser.pugx.org/jeremykenedy/laravel-exception-notifier/d/total.svg)](https://packagist.org/packages/jeremykenedy/laravel-exception-notifier)
 [![Latest Stable Version](https://poser.pugx.org/jeremykenedy/laravel-exception-notifier/v/stable.svg)](https://packagist.org/packages/jeremykenedy/laravel-exception-notifier)
@@ -18,17 +18,20 @@ Table of contents:
 - [License](#license)
 
 ## About
-Laravel exception notifier will send an email of the error along with the stack trace to the chosen recipients. [This Package](https://packagist.org/packages/jeremykenedy/laravel-exception-notifier) includes all necessary traits, views, configs, and Mailers for email notifications upon your applications exceptions. You can customize who send to, cc to, bcc to, enable/disable, and custom subject or default subject based on environment. Built for Laravel 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 6, 7, 8, and 9+.
+Laravel exception notifier will send an email of the error along with the stack trace to the chosen recipients.
+[This Package](https://packagist.org/packages/jeremykenedy/laravel-exception-notifier) includes all necessary traits, views, configs, and Mailers for email notifications upon your applications exceptions.
+You can customize who send to, cc to, bcc to, enable/disable, and custom subject or default subject based on environment.
+Built for Laravel 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 6, 7, 8, 9, and 10.
 
 Get the errors and fix them before the client even reports them, that's why this exists!
 
 ## Requirements
-* [Laravel 5.2+, 6, 7, 8, or 9+](https://laravel.com/docs/installation)
+* [Laravel 5.2+, 6, 7, 8, 9, or 10](https://laravel.com/docs/installation)
 
 ## Installation Instructions
 1. From your projects root folder in terminal run:
 
-    Laravel 9+ use:
+    Laravel 9-10 use:
 
     ```bash
         composer require jeremykenedy/laravel-exception-notifier
@@ -63,7 +66,7 @@ Register the package with laravel in `config/app.php` under `providers` with the
     php artisan vendor:publish --tag=laravelexceptionnotifier
 ```
 
-#### NOTE: If upgrading to Laravel 9 from an older version of this package you will need to republish the assets with:
+#### NOTE: If upgrading to Laravel 9 or 10 from an older version of this package you will need to republish the assets with:
 
 ```bash
     php artisan vendor:publish --force --tag=laravelexceptionnotifier

--- a/readme.md
+++ b/readme.md
@@ -130,9 +130,9 @@ Register the package with laravel in `config/app.php` under `providers` with the
     public function register(): void
     {
         $this->reportable(function (Throwable $e) {
-            $enableEmailExceptions = config('emailExceptionEnabled');
+            $enableEmailExceptions = config('exceptions.emailExceptionEnabled');
 
-            if ($enableEmailExceptions && $this->shouldReport($e)) {
+            if ($enableEmailExceptions) {
                 $this->sendEmail($e);
             }
         });

--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,7 @@ Register the package with laravel in `config/app.php` under `providers` with the
     public function register(): void
     {
         $this->reportable(function (Throwable $e) {
-            $enableEmailExceptions = config('exceptions.emailExceptionEnabled');
+            $enableEmailExceptions = config('emailExceptionEnabled');
 
             if ($enableEmailExceptions && $this->shouldReport($e)) {
                 $this->sendEmail($e);

--- a/readme.md
+++ b/readme.md
@@ -78,9 +78,9 @@ Register the package with laravel in `config/app.php` under `providers` with the
 
 ```php
     use App\Mail\ExceptionOccurred;
-    use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
     use Illuminate\Support\Facades\Log;
-    use Mail;
+    use Illuminate\Support\Facades\Mail;
+    use Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer;
     use Throwable;
 ```
 
@@ -150,7 +150,7 @@ Register the package with laravel in `config/app.php` under `providers` with the
     /**
      * Sends an email upon exception.
      *
-     * @param \Throwable $exception
+     * @param Throwable $exception
      *
      * @return void
      */

--- a/src/App/Mail/ExceptionOccurred.php
+++ b/src/App/Mail/ExceptionOccurred.php
@@ -58,7 +58,7 @@ class ExceptionOccurred extends Mailable
         return new Content(
             view: $view,
             with: [
-                'content' => $this->content
+                'content' => $this->content,
             ]
         );
     }

--- a/src/App/Mail/ExceptionOccurred.php
+++ b/src/App/Mail/ExceptionOccurred.php
@@ -6,7 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 
-class ExceptionOccured extends Mailable
+class ExceptionOccurred extends Mailable
 {
     use Queueable, SerializesModels;
 

--- a/src/App/Mail/ExceptionOccurred.php
+++ b/src/App/Mail/ExceptionOccurred.php
@@ -25,9 +25,9 @@ class ExceptionOccurred extends Mailable
      */
     public function build(): Mailable
     {
-        $emailsTo = str_getcsv(config('exceptions.emailExceptionsTo'), ',');
-        $ccEmails = str_getcsv(config('exceptions.emailExceptionCCto'), ',');
-        $bccEmails = str_getcsv(config('exceptions.emailExceptionBCCto'), ',');
+        $emailsTo = str_getcsv(config('exceptions.emailExceptionsTo'));
+        $ccEmails = str_getcsv(config('exceptions.emailExceptionCCto'));
+        $bccEmails = str_getcsv(config('exceptions.emailExceptionBCCto'));
         $fromSender = config('exceptions.emailExceptionFrom');
         $subject = config('exceptions.emailExceptionSubject');
 

--- a/src/App/Mail/ExceptionOccurred.php
+++ b/src/App/Mail/ExceptionOccurred.php
@@ -10,12 +10,10 @@ class ExceptionOccurred extends Mailable
 {
     use Queueable, SerializesModels;
 
-    private $content;
+    private array $content;
 
     /**
      * Create a new message instance.
-     *
-     * @return void
      */
     public function __construct($content)
     {
@@ -24,10 +22,8 @@ class ExceptionOccurred extends Mailable
 
     /**
      * Build the message.
-     *
-     * @return $this
      */
-    public function build()
+    public function build(): Mailable
     {
         $emailsTo = str_getcsv(config('exceptions.emailExceptionsTo'), ',');
         $ccEmails = str_getcsv(config('exceptions.emailExceptionCCto'), ',');

--- a/src/App/Mail/ExceptionOccurred.php
+++ b/src/App/Mail/ExceptionOccurred.php
@@ -25,18 +25,18 @@ class ExceptionOccurred extends Mailable
      */
     public function build(): Mailable
     {
-        $emailsTo = str_getcsv(config('exceptions.emailExceptionsTo', ''));
-        $ccEmails = str_getcsv(config('exceptions.emailExceptionCCto', ''));
-        $bccEmails = str_getcsv(config('exceptions.emailExceptionBCCto', ''));
-        $fromSender = config('exceptions.emailExceptionFrom', '');
-        $subject = config('exceptions.emailExceptionSubject', '');
+        $emailsTo = str_getcsv(config('emailExceptionsTo', ''));
+        $ccEmails = str_getcsv(config('emailExceptionCCto', ''));
+        $bccEmails = str_getcsv(config('emailExceptionBCCto', ''));
+        $fromSender = config('emailExceptionFrom', '');
+        $subject = config('emailExceptionSubject', '');
 
         return $this->from($fromSender)
                     ->to($emailsTo)
                     ->cc($ccEmails)
                     ->bcc($bccEmails)
                     ->subject($subject)
-                    ->view(config('exceptions.emailExceptionView'))
+                    ->view(config('emailExceptionView'))
                     ->with('content', $this->content);
     }
 }

--- a/src/App/Mail/ExceptionOccurred.php
+++ b/src/App/Mail/ExceptionOccurred.php
@@ -25,11 +25,11 @@ class ExceptionOccurred extends Mailable
      */
     public function build(): Mailable
     {
-        $emailsTo = str_getcsv(config('exceptions.emailExceptionsTo'));
-        $ccEmails = str_getcsv(config('exceptions.emailExceptionCCto'));
-        $bccEmails = str_getcsv(config('exceptions.emailExceptionBCCto'));
-        $fromSender = config('exceptions.emailExceptionFrom');
-        $subject = config('exceptions.emailExceptionSubject');
+        $emailsTo = str_getcsv(config('exceptions.emailExceptionsTo', ''));
+        $ccEmails = str_getcsv(config('exceptions.emailExceptionCCto', ''));
+        $bccEmails = str_getcsv(config('exceptions.emailExceptionBCCto', ''));
+        $fromSender = config('exceptions.emailExceptionFrom', '');
+        $subject = config('exceptions.emailExceptionSubject', '');
 
         return $this->from($fromSender)
                     ->to($emailsTo)

--- a/src/App/Mail/ExceptionOccurred.php
+++ b/src/App/Mail/ExceptionOccurred.php
@@ -35,26 +35,6 @@ class ExceptionOccurred extends Mailable
         $fromSender = config('exceptions.emailExceptionFrom');
         $subject = config('exceptions.emailExceptionSubject');
 
-        if ($emailsTo[0] === null) {
-            $emailsTo = config('exceptions.emailExceptionsToDefault');
-        }
-
-        if ($ccEmails[0] === null) {
-            $ccEmails = config('exceptions.emailExceptionCCtoDefault');
-        }
-
-        if ($bccEmails[0] === null) {
-            $bccEmails = config('exceptions.emailExceptionBCCtoDefault');
-        }
-
-        if (! $fromSender) {
-            $fromSender = config('exceptions.emailExceptionFromDefault');
-        }
-
-        if (! $subject) {
-            $subject = config('exceptions.emailExceptionSubjectDefault');
-        }
-
         return $this->from($fromSender)
                     ->to($emailsTo)
                     ->cc($ccEmails)

--- a/src/App/Mail/ExceptionOccurred.php
+++ b/src/App/Mail/ExceptionOccurred.php
@@ -4,6 +4,8 @@ namespace App\Mail;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
 class ExceptionOccurred extends Mailable
@@ -21,22 +23,43 @@ class ExceptionOccurred extends Mailable
     }
 
     /**
-     * Build the message.
+     * Get the message envelope.
      */
-    public function build(): Mailable
+    public function envelope(): Envelope
     {
-        $emailsTo = str_getcsv(config('emailExceptionsTo', ''));
-        $ccEmails = str_getcsv(config('emailExceptionCCto', ''));
-        $bccEmails = str_getcsv(config('emailExceptionBCCto', ''));
-        $fromSender = config('emailExceptionFrom', '');
-        $subject = config('emailExceptionSubject', '');
+        $emailsTo = config('exceptions.emailExceptionsTo', false) ?
+            str_getcsv(config('exceptions.emailExceptionsTo')) :
+            null;
+        $emailsCc = config('exceptions.emailExceptionCCto', false) ?
+            str_getcsv(config('exceptions.emailExceptionCCto')) :
+            null;
+        $emailsBcc = config('exceptions.emailExceptionBCCto', false) ?
+            str_getcsv(config('exceptions.emailExceptionBCCto')) :
+            null;
+        $fromSender = config('exceptions.emailExceptionFrom');
+        $subject = config('exceptions.emailExceptionSubject');
 
-        return $this->from($fromSender)
-                    ->to($emailsTo)
-                    ->cc($ccEmails)
-                    ->bcc($bccEmails)
-                    ->subject($subject)
-                    ->view(config('emailExceptionView'))
-                    ->with('content', $this->content);
+        return new Envelope(
+            from: $fromSender,
+            to: $emailsTo,
+            cc: $emailsCc,
+            bcc: $emailsBcc,
+            subject: $subject
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        $view = config('exceptions.emailExceptionView');
+
+        return new Content(
+            view: $view,
+            with: [
+                'content' => $this->content
+            ]
+        );
     }
 }

--- a/src/App/Traits/ExceptionNotificationHandlerTrait.php
+++ b/src/App/Traits/ExceptionNotificationHandlerTrait.php
@@ -32,7 +32,7 @@ trait ExceptionNotificationHandlerTrait
      * @param Throwable $exception
      * @return void
      */
-    public function report(Throwable $exception)
+    public function report(Throwable $e): void
     {
         $enableEmailExceptions = config('exceptions.emailExceptionEnabled');
 
@@ -41,12 +41,12 @@ trait ExceptionNotificationHandlerTrait
         }
 
         if ($enableEmailExceptions) {
-            if ($this->shouldReport($exception)) {
-                $this->sendEmail($exception);
+            if ($this->shouldReport($e)) {
+                $this->sendEmail($e);
             }
         }
 
-        parent::report($exception);
+        parent::report($e);
     }
 
     /**

--- a/src/App/Traits/ExceptionNotificationHandlerTrait.php
+++ b/src/App/Traits/ExceptionNotificationHandlerTrait.php
@@ -28,9 +28,6 @@ trait ExceptionNotificationHandlerTrait
      * Report or log an exception.
      *
      * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
-     *
-     * @param Throwable $exception
-     * @return void
      */
     public function report(Throwable $e): void
     {
@@ -51,11 +48,8 @@ trait ExceptionNotificationHandlerTrait
 
     /**
      * Sends an email upon exception.
-     *
-     * @param Throwable $exception
-     * @return void
      */
-    public function sendEmail(Throwable $exception)
+    public function sendEmail(Throwable $exception): void
     {
         try {
             $hasDebugModeEnabled = app()->hasDebugModeEnabled();

--- a/src/App/Traits/ExceptionNotificationHandlerTrait.php
+++ b/src/App/Traits/ExceptionNotificationHandlerTrait.php
@@ -5,8 +5,8 @@ namespace App\Traits;
 use App\Mail\ExceptionOccurred;
 use Illuminate\Support\Facades\Log;
 use Mail;
-use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\ErrorHandler\ErrorHandler as SymfonyExceptionHandler;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Throwable;
 
 trait ExceptionNotificationHandlerTrait

--- a/src/App/Traits/ExceptionNotificationHandlerTrait.php
+++ b/src/App/Traits/ExceptionNotificationHandlerTrait.php
@@ -27,8 +27,10 @@ trait ExceptionNotificationHandlerTrait
      * Report or log an exception.
      *
      * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
+     *
+     * @return void
      */
-    public function report(Throwable $e): void
+    public function report(Throwable $e)
     {
         $enableEmailExceptions = config('exceptions.emailExceptionEnabled');
 

--- a/src/App/Traits/ExceptionNotificationHandlerTrait.php
+++ b/src/App/Traits/ExceptionNotificationHandlerTrait.php
@@ -5,8 +5,7 @@ namespace App\Traits;
 use App\Mail\ExceptionOccurred;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
-use Symfony\Component\ErrorHandler\ErrorHandler as SymfonyExceptionHandler;
-use Symfony\Component\ErrorHandler\Exception\FlattenException;
+use Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer;
 use Throwable;
 
 trait ExceptionNotificationHandlerTrait
@@ -59,9 +58,9 @@ trait ExceptionNotificationHandlerTrait
     public function sendEmail(Throwable $exception)
     {
         try {
-            $e = FlattenException::create($exception);
-            $handler = new SymfonyExceptionHandler();
-            $html = $handler->getHtml($e);
+            $hasDebugModeEnabled = app()->hasDebugModeEnabled();
+            $renderer = new HtmlErrorRenderer($hasDebugModeEnabled);
+            $html = $renderer->render($exception);
 
             Mail::send(new ExceptionOccurred($html));
         } catch (Throwable $exception) {

--- a/src/App/Traits/ExceptionNotificationHandlerTrait.php
+++ b/src/App/Traits/ExceptionNotificationHandlerTrait.php
@@ -24,27 +24,17 @@ trait ExceptionNotificationHandlerTrait
     ];
 
     /**
-     * Report or log an exception.
-     *
-     * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
-     *
-     * @return void
+     * Register the exception handling callbacks for the application.
      */
-    public function report(Throwable $e)
+    public function register(): void
     {
-        $enableEmailExceptions = config('exceptions.emailExceptionEnabled');
+        $this->reportable(function (Throwable $e) {
+            $enableEmailExceptions = config('exceptions.emailExceptionEnabled', true);
 
-        if ($enableEmailExceptions === '') {
-            $enableEmailExceptions = config('exceptions.emailExceptionEnabledDefault');
-        }
-
-        if ($enableEmailExceptions) {
-            if ($this->shouldReport($e)) {
+            if ($enableEmailExceptions && $this->shouldReport($e)) {
                 $this->sendEmail($e);
             }
-        }
-
-        parent::report($e);
+        });
     }
 
     /**

--- a/src/App/Traits/ExceptionNotificationHandlerTrait.php
+++ b/src/App/Traits/ExceptionNotificationHandlerTrait.php
@@ -29,9 +29,9 @@ trait ExceptionNotificationHandlerTrait
     public function register(): void
     {
         $this->reportable(function (Throwable $e) {
-            $enableEmailExceptions = config('emailExceptionEnabled');
+            $enableEmailExceptions = config('exceptions.emailExceptionEnabled');
 
-            if ($enableEmailExceptions && $this->shouldReport($e)) {
+            if ($enableEmailExceptions) {
                 $this->sendEmail($e);
             }
         });

--- a/src/App/Traits/ExceptionNotificationHandlerTrait.php
+++ b/src/App/Traits/ExceptionNotificationHandlerTrait.php
@@ -2,7 +2,7 @@
 
 namespace App\Traits;
 
-use App\Mail\ExceptionOccured;
+use App\Mail\ExceptionOccurred;
 use Illuminate\Support\Facades\Log;
 use Mail;
 use Symfony\Component\Debug\Exception\FlattenException;
@@ -63,7 +63,7 @@ trait ExceptionNotificationHandlerTrait
             $handler = new SymfonyExceptionHandler();
             $html = $handler->getHtml($e);
 
-            Mail::send(new ExceptionOccured($html));
+            Mail::send(new ExceptionOccurred($html));
         } catch (Throwable $exception) {
             Log::error($exception);
         }

--- a/src/App/Traits/ExceptionNotificationHandlerTrait.php
+++ b/src/App/Traits/ExceptionNotificationHandlerTrait.php
@@ -4,7 +4,7 @@ namespace App\Traits;
 
 use App\Mail\ExceptionOccurred;
 use Illuminate\Support\Facades\Log;
-use Mail;
+use Illuminate\Support\Facades\Mail;
 use Symfony\Component\ErrorHandler\ErrorHandler as SymfonyExceptionHandler;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Throwable;

--- a/src/App/Traits/ExceptionNotificationHandlerTrait.php
+++ b/src/App/Traits/ExceptionNotificationHandlerTrait.php
@@ -45,12 +45,12 @@ trait ExceptionNotificationHandlerTrait
         try {
             $content = [
                 'message' => $exception->getMessage(),
-                'file' => $exception->getFile(),
-                'line' => $exception->getLine(),
-                'trace' => $exception->getTrace(),
-                'url' => request()->url(),
-                'body' => request()->all(),
-                'ip' => request()->ip(),
+                'file'    => $exception->getFile(),
+                'line'    => $exception->getLine(),
+                'trace'   => $exception->getTrace(),
+                'url'     => request()->url(),
+                'body'    => request()->all(),
+                'ip'      => request()->ip(),
             ];
 
             Mail::send(new ExceptionOccurred($content));

--- a/src/App/Traits/ExceptionNotificationHandlerTrait.php
+++ b/src/App/Traits/ExceptionNotificationHandlerTrait.php
@@ -29,7 +29,7 @@ trait ExceptionNotificationHandlerTrait
     public function register(): void
     {
         $this->reportable(function (Throwable $e) {
-            $enableEmailExceptions = config('exceptions.emailExceptionEnabled', true);
+            $enableEmailExceptions = config('emailExceptionEnabled');
 
             if ($enableEmailExceptions && $this->shouldReport($e)) {
                 $this->sendEmail($e);

--- a/src/App/Traits/ExceptionNotificationHandlerTrait.php
+++ b/src/App/Traits/ExceptionNotificationHandlerTrait.php
@@ -30,7 +30,7 @@ trait ExceptionNotificationHandlerTrait
      *
      * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
      *
-     * @param  \Throwable  $exception
+     * @param Throwable $exception
      * @return void
      */
     public function report(Throwable $exception)
@@ -53,7 +53,7 @@ trait ExceptionNotificationHandlerTrait
     /**
      * Sends an email upon exception.
      *
-     * @param  \Throwable  $exception
+     * @param Throwable $exception
      * @return void
      */
     public function sendEmail(Throwable $exception)

--- a/src/App/Traits/ExceptionNotificationHandlerTrait.php
+++ b/src/App/Traits/ExceptionNotificationHandlerTrait.php
@@ -5,7 +5,6 @@ namespace App\Traits;
 use App\Mail\ExceptionOccurred;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
-use Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer;
 use Throwable;
 
 trait ExceptionNotificationHandlerTrait
@@ -52,11 +51,17 @@ trait ExceptionNotificationHandlerTrait
     public function sendEmail(Throwable $exception): void
     {
         try {
-            $hasDebugModeEnabled = app()->hasDebugModeEnabled();
-            $renderer = new HtmlErrorRenderer($hasDebugModeEnabled);
-            $html = $renderer->render($exception);
+            $content = [
+                'message' => $exception->getMessage(),
+                'file' => $exception->getFile(),
+                'line' => $exception->getLine(),
+                'trace' => $exception->getTrace(),
+                'url' => request()->url(),
+                'body' => request()->all(),
+                'ip' => request()->ip(),
+            ];
 
-            Mail::send(new ExceptionOccurred($html));
+            Mail::send(new ExceptionOccurred($content));
         } catch (Throwable $exception) {
             Log::error($exception);
         }

--- a/src/LaravelExceptionNotifier.php
+++ b/src/LaravelExceptionNotifier.php
@@ -48,7 +48,7 @@ class LaravelExceptionNotifier extends ServiceProvider
 
         // Publish Mailer
         $this->publishes([
-            __DIR__.'/App/Mail/ExceptionOccured.php' => app_path('Mail/ExceptionOccured.php'),
+            __DIR__.'/App/Mail/ExceptionOccurred.php' => app_path('Mail/ExceptionOccurred.php'),
         ], $publishTag);
 
         // Publish email view

--- a/src/config/exceptions.php
+++ b/src/config/exceptions.php
@@ -10,9 +10,7 @@ return [
     | Enable/Disable exception email notifications
     |
     */
-
-    'emailExceptionEnabled'        => env('EMAIL_EXCEPTION_ENABLED'),
-    'emailExceptionEnabledDefault' => true,
+    'emailExceptionEnabled' => env('EMAIL_EXCEPTION_ENABLED', true),
 
     /*
     |--------------------------------------------------------------------------
@@ -22,9 +20,7 @@ return [
     | This is the email your exception will be from.
     |
     */
-
-    'emailExceptionFrom'        => env('EMAIL_EXCEPTION_FROM'),
-    'emailExceptionFromDefault' => 'email@email.com',
+    'emailExceptionFrom' => env('EMAIL_EXCEPTION_FROM', ''),
 
     /*
     |--------------------------------------------------------------------------
@@ -34,9 +30,7 @@ return [
     | This is the email(s) the exceptions will be emailed to.
     |
     */
-
-    'emailExceptionsTo'        => env('EMAIL_EXCEPTION_TO'),
-    'emailExceptionsToDefault' => 'email@email.com',
+    'emailExceptionsTo' => env('EMAIL_EXCEPTION_TO', ''),
 
     /*
     |--------------------------------------------------------------------------
@@ -46,9 +40,7 @@ return [
     | This is the email(s) the exceptions will be CC emailed to.
     |
     */
-
-    'emailExceptionCCto'        => env('EMAIL_EXCEPTION_CC'),
-    'emailExceptionCCtoDefault' => [],
+    'emailExceptionCCto' => env('EMAIL_EXCEPTION_CC', []),
 
     /*
     |--------------------------------------------------------------------------
@@ -58,9 +50,7 @@ return [
     | This is the email(s) the exceptions will be BCC emailed to.
     |
     */
-
-    'emailExceptionBCCto'        => env('EMAIL_EXCEPTION_BCC'),
-    'emailExceptionBCCtoDefault' => [],
+    'emailExceptionBCCto' => env('EMAIL_EXCEPTION_BCC', []),
 
     /*
     |--------------------------------------------------------------------------
@@ -70,9 +60,7 @@ return [
     | This is the subject of the exception email
     |
     */
-
-    'emailExceptionSubject'        => env('EMAIL_EXCEPTION_SUBJECT'),
-    'emailExceptionSubjectDefault' => 'Error on '.config('app.env'),
+    'emailExceptionSubject' => env('EMAIL_EXCEPTION_SUBJECT', 'Error on ' . config('app.env')),
 
     /*
     |--------------------------------------------------------------------------
@@ -82,7 +70,6 @@ return [
     | This is the view that will be used for the email.
     |
     */
-
     'emailExceptionView' => 'emails.exception',
 
 ];

--- a/src/config/exceptions.php
+++ b/src/config/exceptions.php
@@ -60,7 +60,7 @@ return [
     | This is the subject of the exception email
     |
     */
-    'emailExceptionSubject' => env('EMAIL_EXCEPTION_SUBJECT', 'Error on ' . config('app.env')),
+    'emailExceptionSubject' => env('EMAIL_EXCEPTION_SUBJECT', 'Error on '.config('app.env')),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/config/exceptions.php
+++ b/src/config/exceptions.php
@@ -40,7 +40,7 @@ return [
     | This is the email(s) the exceptions will be CC emailed to.
     |
     */
-    'emailExceptionCCto' => env('EMAIL_EXCEPTION_CC', []),
+    'emailExceptionCCto' => env('EMAIL_EXCEPTION_CC', ''),
 
     /*
     |--------------------------------------------------------------------------
@@ -50,7 +50,7 @@ return [
     | This is the email(s) the exceptions will be BCC emailed to.
     |
     */
-    'emailExceptionBCCto' => env('EMAIL_EXCEPTION_BCC', []),
+    'emailExceptionBCCto' => env('EMAIL_EXCEPTION_BCC', ''),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/config/exceptions.php
+++ b/src/config/exceptions.php
@@ -20,7 +20,7 @@ return [
     | This is the email your exception will be from.
     |
     */
-    'emailExceptionFrom' => env('EMAIL_EXCEPTION_FROM', ''),
+    'emailExceptionFrom' => env('EMAIL_EXCEPTION_FROM'),
 
     /*
     |--------------------------------------------------------------------------
@@ -30,7 +30,7 @@ return [
     | This is the email(s) the exceptions will be emailed to.
     |
     */
-    'emailExceptionsTo' => env('EMAIL_EXCEPTION_TO', ''),
+    'emailExceptionsTo' => env('EMAIL_EXCEPTION_TO'),
 
     /*
     |--------------------------------------------------------------------------
@@ -40,7 +40,7 @@ return [
     | This is the email(s) the exceptions will be CC emailed to.
     |
     */
-    'emailExceptionCCto' => env('EMAIL_EXCEPTION_CC', ''),
+    'emailExceptionCCto' => env('EMAIL_EXCEPTION_CC'),
 
     /*
     |--------------------------------------------------------------------------
@@ -50,7 +50,7 @@ return [
     | This is the email(s) the exceptions will be BCC emailed to.
     |
     */
-    'emailExceptionBCCto' => env('EMAIL_EXCEPTION_BCC', ''),
+    'emailExceptionBCCto' => env('EMAIL_EXCEPTION_BCC'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Hi @jeremykenedy 👋 ,
thank you for providing this package!

This PR aims at providing Laravel 10 support. Additionally, the tests were updated for the latest supported PHP minor releases. Some of the exception handling functionality was also adapted for registration of an error reporting closure as stated in the [Laravel documentation](https://laravel.com/docs/9.x/errors#reporting-exceptions).
Also refactored the configuration to make use of the fallback mechanisms of the newer Laravel versions.

Please let me know what you think and if it could be merged, thanks.